### PR TITLE
Tag prevent simultaneous pet applications us24.rb

### DIFF
--- a/app/views/pet_applications/show.html.erb
+++ b/app/views/pet_applications/show.html.erb
@@ -12,10 +12,12 @@
 <div><h3>Pet Applications</h3>
   <%= form_tag "/pet_applications/#{@pet_application.id}/approve_application", method: :patch do %>
     <% @pet_application.pets.each do |pet| %>
-      <div id="app-<%= @pet_application.id %>-pet-<%= pet.id %>">
-        <%= check_box_tag("pet_id[]", "#{pet.id}") %>
-        <%= label_tag("pet_id[]", "#{pet.name}") %><br/>
-      </div>
+      <% unless pet.adopt_status == "Pending" %>
+        <div id="app-<%= @pet_application.id %>-pet-<%= pet.id %>">
+          <%= check_box_tag("pet_id[]", "#{pet.id}") %>
+          <%= label_tag("pet_id[]", "#{pet.name}") %><br/>
+        </div>
+      <% end %>
     <% end %>
 
     <%= submit_tag "Approve Applications" %>

--- a/spec/features/applications/cannot_approve_mulitple_applications_spec.rb
+++ b/spec/features/applications/cannot_approve_mulitple_applications_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe 'As a visitor' do
         click_link "Favorite Pet"
       end
 
+      visit "/pets/#{@pet_3.id}"
+
+      within "section" do
+        click_link "Favorite Pet"
+      end
+
       visit("/favorites")
 
       click_link "Adopt Favorite Pets"
@@ -48,6 +54,10 @@ RSpec.describe 'As a visitor' do
 
       within("#pet-#{@pet_2.id}") do
         check "#{@pet_2.name}"
+      end
+
+      within("#pet-#{@pet_3.id}") do
+        check "#{@pet_3.name}"
       end
 
       fill_in :name, with: "Jesse"
@@ -86,53 +96,11 @@ RSpec.describe 'As a visitor' do
         expect(page).to have_content("Status: Pending")
       end
 
-      reset_session!
-      visit("/")
-
-      within 'nav' do
-        expect(page).to have_content("Favorite Pets: 0")
-      end
-
-      visit "/pets/#{@pet_2.id}"
-
-      within "section" do
-        click_link "Favorite Pet"
-      end
-
       visit "/pets/#{@pet_3.id}"
 
       within "section" do
-        click_link "Favorite Pet"
+        expect(page).to have_content("Status: Application Submitted")
       end
-
-      visit("/favorites")
-
-      click_link "Adopt Favorite Pets"
-
-      expect(current_path).to eq("/pet_applications/new")
-
-
-
-      within("#pet-#{@pet_2.id}") do
-        check "#{@pet_2.name}"
-      end
-
-      within("#pet-#{@pet_3.id}") do
-        check "#{@pet_3.name}"
-      end
-
-      fill_in :name, with: "Jesse"
-      fill_in :address, with: "12345 Jesse Ave"
-      fill_in :city, with: "Jesse"
-      fill_in :state, with: "CO"
-      fill_in :zip, with: "80120"
-      fill_in :phone_number, with: "303-867-5309"
-      fill_in :description, with: "Because I'm too cool for school"
-
-      click_button "Submit Application"
-
-      expect(current_path).to eq("/favorites")
-      expect(page).to have_content("Your application was submitted successfully!")
 
       visit "/pet_applications/#{PetApplication.last.id}"
       expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
@@ -142,9 +110,8 @@ RSpec.describe 'As a visitor' do
       expect(page).to have_content("303-867-5309")
       expect(page).to have_content("Because I'm too cool for school")
 
-      within"#app-#{PetApplication.last.id}-pet-#{@pet_2.id}" do
-        expect(page).to have_no_content("#{@pet_2.name}")
-      end
+      expect(page).to have_no_content("#app-#{PetApplication.last.id}-pet-#{@pet_2.id}")
+      expect(page).to have_no_content("#{@pet_2.name}")
 
       within "#app-#{PetApplication.last.id}-pet-#{@pet_3.id}" do
         check "#{@pet_3.name}"

--- a/spec/features/applications/cannot_approve_mulitple_applications_spec.rb
+++ b/spec/features/applications/cannot_approve_mulitple_applications_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor' do
+  before(:each) do
+        shelter_1 = Shelter.create(
+          name: "Dog-Haven",
+          address:  "1234 Barkers Way",
+          city: "Beagle",
+          state: "MA",
+          zip: "01001"
+        )
+
+        @pet_1 = shelter_1.pets.create!(
+          name: "Charlotte",
+          age: 13,
+          sex: "Female",
+          image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/charlotte.jpg"
+        )
+
+        @pet_2 = shelter_1.pets.create!(
+          name: "Sydney",
+          age: 13,
+          sex: "Female",
+          image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/sydney.jpg"
+        )
+
+        @pet_3 = shelter_1.pets.create!(name: "Huckleberry",
+          description: "I love adventure and haircuts!",
+          age: 8,
+          sex: "Male",
+          image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/hb.jpg")
+  end
+
+  context 'When a pet has more than one application for them & one application has already been approved' do
+    it 'I can not approve any other applications for that pet but all other applications still remain on file' do
+
+      visit "/pets/#{@pet_2.id}"
+
+      within "section" do
+        click_link "Favorite Pet"
+      end
+
+      visit("/favorites")
+
+      click_link "Adopt Favorite Pets"
+
+      expect(current_path).to eq("/pet_applications/new")
+
+      within("#pet-#{@pet_2.id}") do
+        check "#{@pet_2.name}"
+      end
+
+      fill_in :name, with: "Jesse"
+      fill_in :address, with: "12345 Jesse Ave"
+      fill_in :city, with: "Jesse"
+      fill_in :state, with: "CO"
+      fill_in :zip, with: "80120"
+      fill_in :phone_number, with: "303-867-5309"
+      fill_in :description, with: "Because I'm too cool for school"
+
+      click_button "Submit Application"
+
+      expect(current_path).to eq("/favorites")
+      expect(page).to have_content("Your application was submitted successfully!")
+
+      visit "/pet_applications/#{PetApplication.last.id}"
+      expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
+
+      expect(page).to have_content("12345 Jesse Ave")
+      expect(page).to have_content("Jesse, CO 80120")
+      expect(page).to have_content("303-867-5309")
+      expect(page).to have_content("Because I'm too cool for school")
+
+      within "#app-#{PetApplication.last.id}-pet-#{@pet_2.id}" do
+        check "#{@pet_2.name}"
+      end
+
+      click_button "Approve Applications"
+
+      expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
+      expect(page).to have_content("The application(s) are approved!")
+
+      visit "/pets/#{@pet_2.id}"
+
+      within "section" do
+        expect(page).to have_content("Status: Pending")
+      end
+
+      reset_session!
+      visit("/")
+
+      within 'nav' do
+        expect(page).to have_content("Favorite Pets: 0")
+      end
+
+      visit "/pets/#{@pet_2.id}"
+
+      within "section" do
+        click_link "Favorite Pet"
+      end
+
+      visit "/pets/#{@pet_3.id}"
+
+      within "section" do
+        click_link "Favorite Pet"
+      end
+
+      visit("/favorites")
+
+      click_link "Adopt Favorite Pets"
+
+      expect(current_path).to eq("/pet_applications/new")
+
+
+
+      within("#pet-#{@pet_2.id}") do
+        check "#{@pet_2.name}"
+      end
+
+      within("#pet-#{@pet_3.id}") do
+        check "#{@pet_3.name}"
+      end
+
+      fill_in :name, with: "Jesse"
+      fill_in :address, with: "12345 Jesse Ave"
+      fill_in :city, with: "Jesse"
+      fill_in :state, with: "CO"
+      fill_in :zip, with: "80120"
+      fill_in :phone_number, with: "303-867-5309"
+      fill_in :description, with: "Because I'm too cool for school"
+
+      click_button "Submit Application"
+
+      expect(current_path).to eq("/favorites")
+      expect(page).to have_content("Your application was submitted successfully!")
+
+      visit "/pet_applications/#{PetApplication.last.id}"
+      expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
+
+      expect(page).to have_content("12345 Jesse Ave")
+      expect(page).to have_content("Jesse, CO 80120")
+      expect(page).to have_content("303-867-5309")
+      expect(page).to have_content("Because I'm too cool for school")
+
+      within"#app-#{PetApplication.last.id}-pet-#{@pet_2.id}" do
+        expect(page).to have_no_content("#{@pet_2.name}")
+      end
+
+      within "#app-#{PetApplication.last.id}-pet-#{@pet_3.id}" do
+        check "#{@pet_3.name}"
+      end
+
+      click_button "Approve Applications"
+
+      expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
+      expect(page).to have_content("The application(s) are approved!")
+
+      visit "/pets/#{@pet_3.id}"
+
+      within "section" do
+        expect(page).to have_content("Status: Pending")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add US24 to not display applications that have been approved as approvable
- add tests
- add logic to application#show template

Note: kept the already addressed errors from a previous PR for shelters that continues not to pass in this branch to prevent breaking it further across the others...