### PR TITLE
Tag cannot delete pets approved application us31

### DIFF
--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,14 +1,18 @@
 <h1>Pets</h1>
 <section>
   <% @pets.each do |pet| %>
-  <div class="pet_block">
+  <div id="pet-<%= pet.id %>" class="pet_block">
     <div class="pet_image"><%= image_tag ( pet.image ) %></div>
     <h2><%= link_to pet.name, "/pets/#{pet.id}" %></h2>
     <p>Age: <%= pet.age %></p>
     <p>Sex: <%= pet.sex %></p>
     <p>Located at: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %><br>
     <%= link_to "Edit Pet", "/pets/#{pet.id}/edit" %>
-    <%= link_to "Delete Pet", "/pets/#{pet.id}", method: :delete %><br/>
+
+    <% unless pet.adopt_status == "Pending" %>
+      <%= link_to "Delete Pet", "/pets/#{pet.id}", method: :delete %></p>
+    <% end %>
+
   </div>
   <% end %>
 </section>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -14,7 +14,11 @@
   Age: <%= @pet.age %><br/>
   Sex: <%= @pet.sex %><br/>
   <p><%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %>
-  <%= link_to "Delete Pet", "/pets/#{@pet.id}", method: :delete %></p>
+
+  <% unless @pet.adopt_status == "Pending" %>
+    <%= link_to "Delete Pet", "/pets/#{@pet.id}", method: :delete %></p>
+  <% end %>
+
   <p>View <%= link_to "All Applications", "/pets/#{@pet.id}/applications", method: :get %> for <%= @pet.name %>
 </section>
 

--- a/app/views/shelterpets/index.html.erb
+++ b/app/views/shelterpets/index.html.erb
@@ -1,18 +1,23 @@
 <h1> Pets at <%= @shelter.name %> </h1>
 
-<%= link_to "Create Pet", "/shelters/#{@shelter.id}/pets/new" %><br/>
+  <%= link_to "Create Pet", "/shelters/#{@shelter.id}/pets/new" %><br/>
 
-<section>
-<% @shelter.pets.each do |pet| %>
-    <div class="pet_block">
-    <div class="pet_image"><%= image_tag ( pet.image ) %></div>
-    <h2><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h2>
-    <p>Status: <%= pet.adopt_status %>
-    <p>Age: <%= pet.age %></p>
-    <p><%= pet.sex %></p>
-    <p><%= pet.description %></p>
-    <%= link_to "Edit Pet", "/pets/#{pet.id}/edit" %>
-    <%= link_to "Delete Pet", "/pets/#{pet.id}", method: :delete %><br/>
-  </div>
-<% end %>
-</section>
+  <section>
+    <% @shelter.pets.each do |pet| %>
+      <div id="pet-<%= pet.id %>" class="pet_block">
+        <div class="pet_image"><%= image_tag ( pet.image ) %></div>
+        <h2><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h2>
+
+        <p>Status: <%= pet.adopt_status %>
+        <p>Age: <%= pet.age %></p>
+        <p><%= pet.sex %></p>
+        <p><%= pet.description %></p>
+
+        <%= link_to "Edit Pet", "/pets/#{pet.id}/edit" %>
+
+        <% unless pet.adopt_status == "Pending" %>
+          <%= link_to "Delete Pet", "/pets/#{pet.id}", method: :delete %>
+        <% end %>
+      </div>
+    <% end %>
+  </section>

--- a/spec/features/pets/pet_delete_from_pets_index_spec.rb
+++ b/spec/features/pets/pet_delete_from_pets_index_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe "when I visit the pets index page", type: :feature do
                                      sex: "Female",
                                      image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/charlotte.jpg")
 
-      visit "/pets/"
+      visit "/pets"
+
+      within "#pet-#{pet_1.id}" do
         expect(page).to have_content("Delete Pet")
+        click_link "Delete Pet"
+      end
 
-      click_link "Delete Pet"
-        expect(current_path).to eq("/pets")
+      expect(current_path).to eq("/pets")
 
-      expect(page).to_not have_content("Charlotte")
-      expect(page).to_not have_content("13")
-      expect(page).to_not have_content("Female")
-
+      expect(page).to_not have_css("#pet-#{pet_1.id}")
     end
   end
 
@@ -42,17 +42,15 @@ RSpec.describe "when I visit the pets index page", type: :feature do
                                      sex: "Female",
                                      image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/charlotte.jpg")
 
-        visit "/shelters/#{shelter_1.id}/pets"
-          expect(page).to have_content("Delete Pet")
+      visit "/shelters/#{shelter_1.id}/pets"
 
+      within "#pet-#{pet_1.id}" do
+        expect(page).to have_content("Delete Pet")
         click_link "Delete Pet"
-          expect(current_path).to eq("/pets")
+      end
 
-        expect(page).to_not have_content("Charlotte")
-        expect(page).to_not have_content("13")
-        expect(page).to_not have_content("Female")
-
-
+      expect(current_path).to eq("/pets")
+      expect(page).to_not have_css("#pet-#{pet_1.id}")
     end
   end
 end

--- a/spec/features/pets/pet_delete_spec.rb
+++ b/spec/features/pets/pet_delete_spec.rb
@@ -26,11 +26,7 @@ RSpec.describe "when i visit a pets show page", type: :feature do
 
       expect(current_path).to eq("/pets")
 
-      expect(page).to_not have_css("img[src*='#{pet_1.image}']")
-      expect(page).to_not have_content(pet_1.name)
-      expect(page).to_not have_content(pet_1.age)
-      expect(page).to_not have_content(pet_1.sex)
-
+      expect(page).to_not have_css("#pet-#{pet_1.id}")
     end
   end
 end

--- a/spec/features/pets/pet_links_spec.rb
+++ b/spec/features/pets/pet_links_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe "when i click on the name of a shelter", type: :feature do
       expect(page).to have_content("#{pet_1.name}")
 
     click_link "#{pet_1.name}"
-      expect(current_path).to eq("/pets/#{pet_1.id}")
+    expect(current_path).to eq("/pets/#{pet_1.id}")
 
     visit "/shelters/#{shelter_1.id}/pets"
-      expect(page).to have_content("#{pet_1.name}")
+    expect(page).to have_content("#{pet_1.name}")
 
     click_link "#{pet_1.name}"
-      expect(current_path).to eq("/pets/#{pet_1.id}")
+    expect(current_path).to eq("/pets/#{pet_1.id}")
   end
 end

--- a/spec/features/pets/pets_approved_application_cannot_delete_spec.rb
+++ b/spec/features/pets/pets_approved_application_cannot_delete_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe 'As a visitor' do
+
+  before(:each) do
+    @shelter_1 = Shelter.create(
+      name: "Dog-Haven",
+      address:  "1234 Barkers Way",
+      city: "Beagle",
+      state: "MA",
+      zip: "01001"
+    )
+
+    @pet_1 = @shelter_1.pets.create!(
+      name: "Charlotte",
+      age: 13,
+      sex: "Female",
+      image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/charlotte.jpg"
+    )
+
+    @pet_2 = @shelter_1.pets.create!(
+      name: "Sydney",
+      age: 13,
+      sex: "Female",
+      image: "https://raw.githubusercontent.com/mikez321/adopt_dont_shop_2001/master/app/assets/images/sydney.jpg"
+    )
+  end
+
+  describe 'If a pet has an approved application I can not delete the pet' do
+    context "When I visit the shelter pets or pet show page" do
+      it "I do not see the delete the pet" do
+
+        visit "/pets/#{@pet_1.id}"
+
+        within "section" do
+          click_link "Favorite Pet"
+        end
+
+        visit "/pets/#{@pet_2.id}"
+
+        within "section" do
+          click_link "Favorite Pet"
+        end
+
+        visit("/favorites")
+
+        click_link "Adopt Favorite Pets"
+
+        expect(current_path).to eq("/pet_applications/new")
+
+        within("#pet-#{@pet_1.id}") do
+          check "#{@pet_1.name}"
+        end
+
+        within("#pet-#{@pet_2.id}") do
+          check "#{@pet_2.name}"
+        end
+
+        fill_in :name, with: "Jesse"
+        fill_in :address, with: "12345 Jesse Ave"
+        fill_in :city, with: "Jesse"
+        fill_in :state, with: "CO"
+        fill_in :zip, with: "80120"
+        fill_in :phone_number, with: "303-867-5309"
+        fill_in :description, with: "Because I'm too cool for school"
+
+        click_button "Submit Application"
+
+        expect(current_path).to eq("/favorites")
+        expect(page).to have_content("Your application was submitted successfully!")
+
+        visit "/pet_applications/#{PetApplication.last.id}"
+        expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
+
+        expect(page).to have_content("12345 Jesse Ave")
+        expect(page).to have_content("Jesse, CO 80120")
+        expect(page).to have_content("303-867-5309")
+        expect(page).to have_content("Because I'm too cool for school")
+
+        within "#sub-app-#{PetApplication.last.id}-pet-#{@pet_1.id}" do
+          check "#{@pet_1.name}"
+        end
+
+        click_button "Approve Applications"
+
+        expect(current_path).to eq("/pet_applications/#{PetApplication.last.id}")
+        expect(page).to have_content("The application(s) are approved!")
+
+        visit "/shelters/#{@shelter_1.id}/pets"
+
+        expect(page).to have_content("Charlotte")
+
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to_not have_link("Delete Pet")
+        end
+
+        visit "/pets"
+
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to_not have_link("Delete Pet")
+        end
+
+        visit "/pets/#{@pet_1.id}"
+
+        within 'section' do
+          expect(page).to_not have_link("Delete Pet")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add US31 pets approved applications cannot be deleted
- Add logic to pets#show, pets#index, shelterpets#index to not show delete link for Pending status pets
- Add tests for US31 covering these mechanisms